### PR TITLE
Add figure-type linear probe configuration

### DIFF
--- a/configs/figure_type_vith14_linearprobe.yaml
+++ b/configs/figure_type_vith14_linearprobe.yaml
@@ -1,0 +1,12 @@
+dataset:
+  root_dir: /ceph/work/KLP/zihcilin39/ijepa-experient/outputs/figure_type
+  pairs_tsv: pairs.tsv
+  index_json: figure_type_index.json
+  num_classes: 60
+
+optimization:
+  optimizer: ["sgd", "adamw"]
+  lr: [1.0e-4, 1.0e-3, 1.0e-2]
+  weight_decay: [0.0, 0.05, 0.1]
+  batch_size: 64
+  epochs: 20


### PR DESCRIPTION
## Summary
- add figure type linear probe config with dataset paths and hyperparameter ranges
- enable YAML configs and command-line overrides for figure-type training script
- allow choosing optimizer and weight decay when training

## Testing
- `pytest -q` *(fails: No module named 'datasets')*


------
https://chatgpt.com/codex/tasks/task_e_68c12265a7bc8322bb717c9b003e45f5