### PR TITLE
Add W&B-enabled figure-type linear probe

### DIFF
--- a/configs/figure_type_vith14_linearprobe.yaml
+++ b/configs/figure_type_vith14_linearprobe.yaml
@@ -1,12 +1,12 @@
 dataset:
-  root_dir: /ceph/work/KLP/zihcilin39/ijepa-experient/outputs/figure_type
-  pairs_tsv: pairs.tsv
-  index_json: figure_type_index.json
+  root_dir: /ceph/work/KLP/zihcilin39/datasets/CoSyn/diagram
+  pairs_tsv: /ceph/work/KLP/zihcilin39/ijepa-experient/outputs/figure_type/pairs.tsv
+  index_json: /ceph/work/KLP/zihcilin39/ijepa-experient/outputs/figure_type/figure_type_index.json
   num_classes: 60
 
 optimization:
   optimizer: ["sgd", "adamw"]
-  lr: [1.0e-4, 1.0e-3, 1.0e-2]
-  weight_decay: [0.0, 0.05, 0.1]
-  batch_size: 64
-  epochs: 20
+  lr: [0.01, 0.05, 0.1]
+  weight_decay: [5.0e-4, 0.0]
+  batch_size: 256
+  epochs: 50

--- a/job_figure_type_linearprobe.sh
+++ b/job_figure_type_linearprobe.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+#SBATCH --job-name="figure-type-linearprobe"
+#SBATCH --partition=a100-al9
+#SBATCH --reservation=klp_reservation
+#SBATCH --qos=klp_a100_reservation
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --gres=gpu:1
+#SBATCH --cpus-per-task=8
+#SBATCH --time=24:00:00
+#SBATCH --mem=32G
+#SBATCH -o slurm-logs/%j.out
+#SBATCH -e slurm-logs/%j.err
+
+set -e
+
+mkdir -p slurm-logs
+mkdir -p /ceph/work/KLP/zihcilin39/experiments/figure_type_linearprobe
+
+module load anaconda3/2024.10-1
+ENV_NAME="ijepa"
+eval "$(command conda 'shell.bash' 'hook' 2> /dev/null)"
+conda activate $ENV_NAME
+
+# W&B 設定
+export WANDB_API_KEY="db81e71f385b3e8326d37edbb356791a25fb7389"
+export WANDB_MODE="online"
+
+echo "Current conda environment: $CONDA_DEFAULT_ENV"
+echo "Python path: $(which python)"
+echo "PyTorch version: $(python -c 'import torch; print(torch.__version__)')"
+
+# 安裝 wandb（確保可用）
+pip install --quiet wandb
+
+python src/train_figure_type.py \
+  --config configs/figure_type_vith14_linearprobe.yaml \
+  --checkpoint /ceph/work/KLP/zihcilin39/experiments/cosyn_vith14_ep300/jepa-latest.pth.tar \
+  --model-name vit_huge \
+  --repr last \
+  --head linear \
+  --log-to-wandb \
+  --wandb-project ijepa-figure-type \
+  --wandb-run-name figure-type-last-linear
+
+echo "Linear probe training completed!"
+


### PR DESCRIPTION
## Summary
- integrate W&B logging and stratified train/val split into `train_figure_type.py`
- supply dataset paths and hyperparameters for figure-type probing in new config
- add Slurm job script for W&B-enabled linear probe

## Testing
- `python -m py_compile src/train_figure_type.py`
- `python src/train_figure_type.py --help` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch` *(fails: Could not find a version that satisfies the requirement torch)*
- `pip install pyyaml` *(fails: Could not find a version that satisfies the requirement pyyaml)*

------
https://chatgpt.com/codex/tasks/task_e_68c1146ab2088322b1d0bdda792f0581