### PR TITLE
Ensure working directory and module invocation for figure-type job

### DIFF
--- a/job_figure_type_linearprobe.sh
+++ b/job_figure_type_linearprobe.sh
@@ -15,6 +15,8 @@
 
 set -e
 
+cd /ceph/work/KLP/zihcilin39/ijepa-experient
+
 mkdir -p slurm-logs
 mkdir -p /ceph/work/KLP/zihcilin39/experiments/figure_type_linearprobe
 
@@ -34,7 +36,7 @@ echo "PyTorch version: $(python -c 'import torch; print(torch.__version__)')"
 # 安裝 wandb（確保可用）
 pip install --quiet wandb
 
-python src/train_figure_type.py \
+python -m src.train_figure_type \
   --config configs/figure_type_vith14_linearprobe.yaml \
   --checkpoint /ceph/work/KLP/zihcilin39/experiments/cosyn_vith14_ep300/jepa-latest.pth.tar \
   --model-name vit_huge \


### PR DESCRIPTION
## Summary
- Ensure job script switches to repository directory before execution using `/ceph/work/KLP/zihcilin39/ijepa-experient`
- Run figure-type training via module path instead of direct script

## Testing
- `bash -n job_figure_type_linearprobe.sh`
- `pytest` *(fails: No module named 'datasets')*

------
https://chatgpt.com/codex/tasks/task_e_68c12d5d9c4c832288a62bcb386697cb