### PR TITLE
Add W&B-enabled figure-type linear probe

### DIFF
--- a/configs/figure_type_vith14_linearprobe.yaml
+++ b/configs/figure_type_vith14_linearprobe.yaml
@@ -1,12 +1,12 @@
 dataset:
-  root_dir: /ceph/work/KLP/zihcilin39/ijepa-experient/outputs/figure_type
-  pairs_tsv: pairs.tsv
-  index_json: figure_type_index.json
-  num_classes: 60
+  root_dir: /ceph/work/KLP/zihcilin39/datasets/CoSyn/diagram
+  pairs_tsv: /ceph/work/KLP/zihcilin39/ijepa-experient/outputs/figure_type/pairs.tsv
+  index_json: /ceph/work/KLP/zihcilin39/ijepa-experient/outputs/figure_type/figure_type_index.json
+  num_classes: 42
 
 optimization:
   optimizer: ["sgd", "adamw"]
-  lr: [1.0e-4, 1.0e-3, 1.0e-2]
-  weight_decay: [0.0, 0.05, 0.1]
-  batch_size: 64
-  epochs: 20
+  lr: [0.01, 0.05, 0.1]
+  weight_decay: [5.0e-4, 0.0]
+  batch_size: 256
+  epochs: 50

--- a/job_figure_type_linearprobe.sh
+++ b/job_figure_type_linearprobe.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+#SBATCH --job-name="figure-type-linearprobe"
+#SBATCH --partition=a100-al9
+#SBATCH --reservation=klp_reservation
+#SBATCH --qos=klp_a100_reservation
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --gres=gpu:1
+#SBATCH --cpus-per-task=8
+#SBATCH --time=24:00:00
+#SBATCH --mem=32G
+#SBATCH -o slurm-logs/%j.out
+#SBATCH -e slurm-logs/%j.err
+
+set -e
+
+mkdir -p slurm-logs
+mkdir -p /ceph/work/KLP/zihcilin39/experiments/figure_type_linearprobe
+
+module load anaconda3/2024.10-1
+ENV_NAME="ijepa"
+eval "$(command conda 'shell.bash' 'hook' 2> /dev/null)"
+conda activate $ENV_NAME
+
+# W&B 設定
+export WANDB_API_KEY="db81e71f385b3e8326d37edbb356791a25fb7389"
+export WANDB_MODE="online"
+
+echo "Current conda environment: $CONDA_DEFAULT_ENV"
+echo "Python path: $(which python)"
+echo "PyTorch version: $(python -c 'import torch; print(torch.__version__)')"
+
+# 安裝 wandb（確保可用）
+pip install --quiet wandb
+
+python -m src.train_figure_type \
+  --config configs/figure_type_vith14_linearprobe.yaml \
+  --checkpoint /ceph/work/KLP/zihcilin39/experiments/cosyn_vith14_ep300/jepa-latest.pth.tar \
+  --model-name vit_huge \
+  --repr last \
+  --head linear \
+  --log-to-wandb \
+  --wandb-project ijepa-figure-type \
+  --wandb-run-name figure-type-last-linear
+
+echo "Linear probe training completed!"
+

--- a/src/train_figure_type.py
+++ b/src/train_figure_type.py
@@ -22,6 +22,7 @@ import argparse
 import json
 import os
 from typing import Iterable
+from collections import defaultdict
 
 import torch
 import torch.nn as nn
@@ -57,6 +58,10 @@ def _parse_args() -> argparse.Namespace:
                         help="Encoder model architecture")
     parser.add_argument("--batch-size", type=int, default=64)
     parser.add_argument("--epochs", type=int, default=10)
+    parser.add_argument("--val-ratio", type=float, default=0.2,
+                        help="Fraction of data used for validation")
+    parser.add_argument("--seed", type=int, default=0,
+                        help="Random seed for train/val split")
     parser.add_argument("--optimizer", choices=["sgd", "adam", "adamw"],
                         default="adamw")
     parser.add_argument("--lr", type=float, default=1e-3)
@@ -68,6 +73,16 @@ def _parse_args() -> argparse.Namespace:
                         help="Which encoder layer representation to use")
     parser.add_argument("--head", choices=["linear", "bn_linear"],
                         default="linear", help="Classification head type")
+    parser.add_argument("--output-dir", default="experiments/figure_type_linearprobe",
+                        help="Directory to save checkpoints and metrics")
+    parser.add_argument("--log-to-wandb", action="store_true",
+                        help="Log training metrics to Weights & Biases")
+    parser.add_argument("--wandb-project", default=None,
+                        help="W&B project name")
+    parser.add_argument("--wandb-entity", default=None,
+                        help="W&B entity/user name")
+    parser.add_argument("--wandb-run-name", default=None,
+                        help="W&B run name")
 
     if args_config.config is not None:
         import yaml
@@ -105,8 +120,12 @@ def _build_encoder(args: argparse.Namespace) -> nn.Module:
     """Initialise encoder and load weights."""
     encoder = vit.__dict__[args.model_name]()
     state = torch.load(args.checkpoint, map_location="cpu")
-    if "encoder" in state:
-        state = state["encoder"]
+    for key in ("encoder", "model"):
+        if key in state:
+            state = state[key]
+            break
+    if any(k.startswith("module.") for k in state.keys()):
+        state = {k.replace("module.", "", 1): v for k, v in state.items()}
     encoder.load_state_dict(state, strict=True)
     for p in encoder.parameters():
         p.requires_grad = False
@@ -132,10 +151,10 @@ def _extract_representation(encoder: nn.Module, x: torch.Tensor,
         out = encoder.norm(h) if encoder.norm is not None else h
         outputs.append(out)
     if repr_mode == "last":
-        h = outputs[-1]
+        h = outputs[-1].mean(dim=1)
     else:
-        h = torch.stack(outputs[-4:], dim=0).mean(0)
-    h = h.mean(dim=1)
+        pooled = [feat.mean(dim=1) for feat in outputs[-4:]]
+        h = torch.cat(pooled, dim=1)
     return h
 
 
@@ -178,23 +197,32 @@ def evaluate(
     repr_mode: str,
     num_classes: int,
 ) -> dict:
-    """Compute confusion matrix and per-class accuracy."""
+    """Compute validation loss, accuracy and confusion matrix."""
     encoder.eval()
     head.eval()
     confusion = torch.zeros(num_classes, num_classes, dtype=torch.int64)
+    total_loss = 0.0
+    total_correct = 0
+    total_samples = 0
     with torch.no_grad():
         for images, labels in dataloader:
             images = images.to(device)
             labels = labels.to(device)
             feats = _extract_representation(encoder, images, repr_mode)
             logits = head(feats)
+            loss = F.cross_entropy(logits, labels)
             preds = logits.argmax(1)
+            total_loss += loss.item() * images.size(0)
+            total_correct += (preds == labels).sum().item()
+            total_samples += images.size(0)
             for t, p in zip(labels, preds):
                 confusion[t, p] += 1
     per_class_acc = (
         confusion.diag().float() / confusion.sum(dim=1).clamp(min=1).float()
     ).tolist()
     return {
+        "loss": total_loss / total_samples,
+        "accuracy": total_correct / total_samples,
         "confusion_matrix": confusion.tolist(),
         "per_class_accuracy": per_class_acc,
     }
@@ -215,11 +243,13 @@ def main() -> None:
         num_classes = len(index_data.get("name_to_id", {}))
 
     encoder = _build_encoder(args).to(device)
-    head = _build_head(encoder.embed_dim, num_classes, args.head).to(device)
+    embed = encoder.embed_dim * (4 if args.repr == "last4" else 1)
+    head = _build_head(embed, num_classes, args.head).to(device)
 
     transform = make_transforms(
         crop_size=args.crop_size,
         crop_scale=tuple(args.crop_scale),
+        horizontal_flip=True,
     )
     dataset = FigureTypeDataset(
         root_dir=args.root_dir,
@@ -228,15 +258,40 @@ def main() -> None:
         split="train",
         transform=transform,
     )
-    dataloader = DataLoader(
-        dataset,
+
+    # Stratified train/val split
+    rng = torch.Generator().manual_seed(args.seed)
+    class_to_indices: defaultdict[int, list[int]] = defaultdict(list)
+    for idx, (_, label) in enumerate(dataset.samples):
+        class_to_indices[label].append(idx)
+    train_indices: list[int] = []
+    val_indices: list[int] = []
+    for indices in class_to_indices.values():
+        indices = torch.tensor(indices)
+        perm = indices[torch.randperm(len(indices), generator=rng)]
+        split = int(len(perm) * (1 - args.val_ratio))
+        train_indices.extend(perm[:split].tolist())
+        val_indices.extend(perm[split:].tolist())
+
+    train_subset = torch.utils.data.Subset(dataset, train_indices)
+    val_subset = torch.utils.data.Subset(dataset, val_indices)
+
+    train_loader = DataLoader(
+        train_subset,
         batch_size=args.batch_size,
         shuffle=True,
         num_workers=args.num_workers,
         pin_memory=True,
     )
+    val_loader = DataLoader(
+        val_subset,
+        batch_size=args.batch_size,
+        shuffle=False,
+        num_workers=args.num_workers,
+        pin_memory=True,
+    )
 
-    output_dir = os.path.join("outputs", "figure_type")
+    output_dir = args.output_dir
     os.makedirs(output_dir, exist_ok=True)
 
     if args.optimizer == "sgd":
@@ -252,26 +307,45 @@ def main() -> None:
             head.parameters(), lr=args.lr, weight_decay=args.weight_decay
         )
 
+    scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=15, gamma=0.1)
+
+    if args.log_to_wandb:
+        import wandb
+
+        wandb.init(project=args.wandb_project, entity=args.wandb_entity,
+                   name=args.wandb_run_name, config=vars(args))
+        wandb.watch(head, log="all", log_freq=100)
+
     for epoch in range(1, args.epochs + 1):
-        loss, acc = train_one_epoch(
-            dataloader, encoder, head, optimizer, device, args.repr
+        train_loss, train_acc = train_one_epoch(
+            train_loader, encoder, head, optimizer, device, args.repr
         )
-        print(f"Epoch {epoch:03d}: loss={loss:.4f} acc={acc*100:.2f}%")
+        val_metrics = evaluate(
+            val_loader, encoder, head, device, args.repr, num_classes
+        )
+        print(
+            f"Epoch {epoch:03d}: loss={train_loss:.4f} acc={train_acc*100:.2f}% "
+            f"val_loss={val_metrics['loss']:.4f} val_acc={val_metrics['accuracy']*100:.2f}%"
+        )
+        if args.log_to_wandb:
+            wandb.log(
+                {
+                    "epoch": epoch,
+                    "train_loss": train_loss,
+                    "train_acc": train_acc,
+                    "val_loss": val_metrics["loss"],
+                    "val_acc": val_metrics["accuracy"],
+                },
+                step=epoch,
+            )
         if epoch % 10 == 0:
             save_path = os.path.join(output_dir, f"model_epoch{epoch}.pth")
             torch.save({"head": head.state_dict()}, save_path)
+        scheduler.step()
 
-    eval_loader = DataLoader(
-        dataset,
-        batch_size=args.batch_size,
-        shuffle=False,
-        num_workers=args.num_workers,
-        pin_memory=True,
-    )
-    metrics = evaluate(eval_loader, encoder, head, device, args.repr, num_classes)
     metrics_path = os.path.join(output_dir, "metrics.json")
     with open(metrics_path, "w") as f:
-        json.dump(metrics, f, indent=2)
+        json.dump(val_metrics, f, indent=2)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- handle DataParallel checkpoints and freeze encoder for linear probing
- concatenate last 4 layer representations and scale head accordingly
- update config and Slurm job script for 42 classes and module execution

## Testing
- `python -m py_compile src/train_figure_type.py`
- `python -m src.train_figure_type --help` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68c1146ab2088322b1d0bdda792f0581